### PR TITLE
trying to add baseURL to Google Analytics

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import ENV from '../config/environment';
+
+export default Ember.Mixin.create({
+  beforePageviewToGA: function (ga) {
+
+  },
+
+  pageviewToGA: Ember.on('didTransition', function(page, title) {
+    var page = page ? page : this.get('url');
+    page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
+    var title = title ? title : this.get('url');
+
+    if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {
+      var trackerType = Ember.getWithDefault(ENV, 'googleAnalytics.tracker', 'analytics.js');
+
+      if (trackerType === 'analytics.js') {
+        var globalVariable = Ember.getWithDefault(ENV, 'googleAnalytics.globalVariable', 'ga');
+
+        this.beforePageviewToGA(window[globalVariable]);
+
+        window[globalVariable]('send', 'pageview', {
+          page: page,
+          title: title
+        });
+      } else if (trackerType === 'ga.js') {
+        window._gaq.push(['_trackPageview']);
+      }
+    }
+  })
+
+});

--- a/tests/unit/mixins/google-pageview-test.js
+++ b/tests/unit/mixins/google-pageview-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import GooglePageviewMixin from '../../../mixins/google-pageview';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | google pageview');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var GooglePageviewObject = Ember.Object.extend(GooglePageviewMixin);
+  var subject = GooglePageviewObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
The ember-cli-google-analytics library doesn't include `baseURL` in the URLs it reports to Google Analytics. We're trying to override it with that behavior.

We're not seeing any calls to Google Analytics when running this code locally, so we'll test on staging server.