### PR TITLE
fix Transitland banner on production

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    fingerprint: {
+      enabled: false
+    }
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
The Transitland banner png is served by the www-transit-land Jekyll site from `/images`. Feed Registry was including a fingerprint hash in the image file name, which meant it failed loading the file.

Disabling fingerprint hashes, so the file names should match now.

See http://www.ember-cli.com/user-guide/#fingerprinting-and-cdn-urls