### PR TITLE
upgrading ember-qunit dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "1.13.15",
     "ember-load-initializers": "0.1.7",
-    "ember-qunit": "0.4.16",
+    "ember-qunit": "~0.4.17",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
@@ -14,5 +14,8 @@
     "qunit": "~1.20.0",
     "moment": ">= 2.8.0",
     "moment-timezone": ">= 0.1.0"
+  },
+  "resolutions": {
+    "ember-qunit": "~0.4.17"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,13 +7,11 @@
     "ember-data": "1.13.15",
     "ember-load-initializers": "0.1.7",
     "ember-qunit": "~0.4.17",
-    "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "moment": ">= 2.8.0",
-    "moment-timezone": ">= 0.1.0",
-    "qunit-notifications": "~0.1.0"
+    "moment-timezone": ">= 0.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,7 @@
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "moment": ">= 2.8.0",
-    "moment-timezone": ">= 0.1.0"
-  },
-  "resolutions": {
-    "ember-qunit": "~0.4.17"
+    "moment-timezone": ">= 0.1.0",
+    "qunit-notifications": "~0.1.0"
   }
 }


### PR DESCRIPTION
I did this by running `bower install ember-qunit --save`

which returned the following options:

```
Unable to find a suitable version for ember-qunit, please choose one:
    1) ember-qunit#0.4.16 which resolved to 0.4.16 and is required by feed-registry
    2) ember-qunit#~0.4.17 which resolved to 0.4.17

Prefix the choice with ! to persist it to bower.json

? Answer
```

and I answered with `!2`