### PR TITLE
unload all models, recreate feed model when gtfs url route is rendered

### DIFF
--- a/app/create-feed-from-gtfs/service.js
+++ b/app/create-feed-from-gtfs/service.js
@@ -1,41 +1,41 @@
 import Ember from 'ember';
 
 export default Ember.Service.extend({
-  store: Ember.inject.service(),
-  feedModel: null,
-  createFeedModel: function() {
-    var newFeedModel = this.get('store').createRecord('feed', { });
-      this.set('feedModel', newFeedModel);
-  },
-  downloadGtfsArchiveAndParseIntoFeedModel: function(retries) {
-    retries = (retries || 60);
-    if (retries-- <= 0) {
-      throw "Timeout";
-    }
-    var feedModel = this.get('feedModel');
-    var url = feedModel.get('url');
-    var adapter = this.get('store').adapterFor('feeds');
-    var fetch_info_url = adapter.urlPrefix()+'/feeds/fetch_info';
-    var controller = this;
-    var promise = adapter.ajax(fetch_info_url, 'post', {data:{url:url}});
-    promise.then(function(response) {
-      if (response.status == 'complete') {
-        feedModel.set('id', response.feed.onestop_id);
-        feedModel.set('operators_in_feed', response.feed.operators_in_feed);
-        return response.operators.map(function(operator){feedModel.addOperator(operator)});
-      } else if (response.status == 'processing') {
-        return Ember.run.later(controller, function(){this.downloadGtfsArchiveAndParseIntoFeedModel(retries)}, 1000);
-      }
-    });
-    return promise;
-  },
+	store: Ember.inject.service(),
+	feedModel: null,
+	createFeedModel: function() {
+		var newFeedModel = this.get('store').createRecord('feed', { });
+		this.set('feedModel', newFeedModel);
+	},
+	downloadGtfsArchiveAndParseIntoFeedModel: function(retries) {
+		retries = (retries || 60);
+		if (retries-- <= 0) {
+			throw "Timeout";
+		}
+		var feedModel = this.get('feedModel');
+		var url = feedModel.get('url');
+		var adapter = this.get('store').adapterFor('feeds');
+		var fetch_info_url = adapter.urlPrefix()+'/feeds/fetch_info';
+		var controller = this;
+		var promise = adapter.ajax(fetch_info_url, 'post', {data:{url:url}});
+		promise.then(function(response) {
+			if (response.status === 'complete') {
+				feedModel.set('id', response.feed.onestop_id);
+				feedModel.set('operators_in_feed', response.feed.operators_in_feed);
+				return response.operators.map(function(operator){feedModel.addOperator(operator);});
+			} else if (response.status === 'processing') {
+				return Ember.run.later(controller, function(){this.downloadGtfsArchiveAndParseIntoFeedModel(retries);}, 1000);
+			}
+		});
+		return promise;
+		},
 	toChangeset: function() {
     var feedModel = this.get('feedModel');
     var changes = [];
     feedModel.get('operators').map(function(operator){
-      changes.push({action:'createUpdate', operator:operator.toChange()})
+      changes.push({action:'createUpdate', operator:operator.toChange()});
     });
-    changes.push({action:'createUpdate', feed:feedModel.toChange()})
+    changes.push({action:'createUpdate', feed:feedModel.toChange()});
 		var changeset = this.get('store').createRecord('changeset', {
 			notes: 'This is a test. TODO put a custom message here.',
 			payload: {

--- a/app/create-feed-from-gtfs/service.js
+++ b/app/create-feed-from-gtfs/service.js
@@ -3,19 +3,16 @@ import Ember from 'ember';
 export default Ember.Service.extend({
   store: Ember.inject.service(),
   feedModel: null,
-  createOrFindFeedModel: function() {
-    if (this.get('feedModel') == null) {
-      var newFeedModel = this.get('store').createRecord('feed', { });
+  createFeedModel: function() {
+    var newFeedModel = this.get('store').createRecord('feed', { });
       this.set('feedModel', newFeedModel);
-    }
-    return this.get('feedModel');
   },
   downloadGtfsArchiveAndParseIntoFeedModel: function(retries) {
     retries = (retries || 60);
     if (retries-- <= 0) {
-      throw "Timeout"
+      throw "Timeout";
     }
-    var feedModel = this.createOrFindFeedModel();
+    var feedModel = this.get('feedModel');
     var url = feedModel.get('url');
     var adapter = this.get('store').adapterFor('feeds');
     var fetch_info_url = adapter.urlPrefix()+'/feeds/fetch_info';
@@ -30,10 +27,10 @@ export default Ember.Service.extend({
         return Ember.run.later(controller, function(){this.downloadGtfsArchiveAndParseIntoFeedModel(retries)}, 1000);
       }
     });
-    return promise
+    return promise;
   },
 	toChangeset: function() {
-    var feedModel = this.createOrFindFeedModel();
+    var feedModel = this.get('feedModel');
     var changes = [];
     feedModel.get('operators').map(function(operator){
       changes.push({action:'createUpdate', operator:operator.toChange()})

--- a/app/feeds/new/add-operator/route.js
+++ b/app/feeds/new/add-operator/route.js
@@ -3,6 +3,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   createFeedFromGtfsService: Ember.inject.service('create-feed-from-gtfs'),
   model: function() {
-    return this.get('createFeedFromGtfsService').createOrFindFeedModel();
+    return this.get('createFeedFromGtfsService').feedModel;
   }
 });

--- a/app/feeds/new/index/route.js
+++ b/app/feeds/new/index/route.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  createFeedFromGtfsService: Ember.inject.service('create-feed-from-gtfs'),
-  model: function() {
-    return this.get('createFeedFromGtfsService').createOrFindFeedModel();
-  }
+	beforeModel: function(){
+		this.store.unloadAll();
+	},
+	createFeedFromGtfsService: Ember.inject.service('create-feed-from-gtfs'),
+		model: function() {
+		this.get('createFeedFromGtfsService').createFeedModel();
+		return this.get('createFeedFromGtfsService').feedModel;
+	}
 });

--- a/app/feeds/new/license/route.js
+++ b/app/feeds/new/license/route.js
@@ -3,6 +3,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 	createFeedFromGtfsService: Ember.inject.service('create-feed-from-gtfs'),
 	  model: function() {
-	    return this.get('createFeedFromGtfsService').createOrFindFeedModel();
+	    return this.get('createFeedFromGtfsService').feedModel;
 	  }
 });

--- a/app/feeds/new/route.js
+++ b/app/feeds/new/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	
 });


### PR DESCRIPTION
This PR closes issue #81. It does so by unloading all existing models and recreating a feed model each time the url route is called. This solves the problem of the feed url and id persisting despite unloading all models.