### PR TITLE
wrap url submission area in form tag and trigger action next on submit

### DIFF
--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -6,25 +6,27 @@
 		Ready to start adding a feed to Transitland? Step #1 is to find the URL for a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. The feed should live on a transit authority's server or another authoritative source.
 	</p>
 </div>
-<div class="container email-input-form">
-	<div class="row">
-		<div class="col-sm-12">
-			<div class="input-form-label">GTFS feed URL</div>
-			<div class="input-form-field">{{input type="text" value=model.url placeholder="http://..."}}</div>
+<form {{action "next" on="submit"}}>
+	<div class="container email-input-form">
+		<div class="row">
+			<div class="col-sm-12">
+				<div class="input-form-label">GTFS feed URL</div>
+				<div class="input-form-field">{{input type="text" value=model.url placeholder="http://..."}}</div>
+			</div>
 		</div>
 	</div>
-</div>
-<br>
-<div class="container email-caption">
-	After this feed is added to Transitland, our servers will periodically check this URL for updates
-</div>
-<br>
-<div class="container email-input-form">
-
-	<div align="left">
-		{{#link-to 'index' class="btn btn-default"}}
-				Cancel
-		{{/link-to}}
-		<a class="btn btn-default" role="button" {{action "next"}}>Next ></a>
+	<br>
+	<div class="container email-caption">
+		After this feed is added to Transitland, our servers will periodically check this URL for updates
 	</div>
-</div>
+	<br>
+	<div class="container email-input-form">
+
+		<div align="left">
+			{{#link-to 'index' class="btn btn-default"}}
+					Cancel
+			{{/link-to}}
+			<a class="btn btn-default" role="button"  type="submit" {{action "next"}}>Next ></a>
+		</div>
+	</div>
+</form>


### PR DESCRIPTION
closes #106 

This PR adds functionality to submit url and move to next step in flow by clicking "next" button or hitting enter/return key. Previously, the only option was to click the "next" button.