### PR TITLE
Minimum operator#107

### DIFF
--- a/app/components/operator-form/component.js
+++ b/app/components/operator-form/component.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+	operatorsIncluded: Ember.computed.mapBy('operators', 'name'),
+	uniqueOperators: Ember.computed.uniq('operatorsIncluded'),
+	operatorsInFeed: Ember.get('this.operatorsInFeed'),
+	singleOperator: function(){
+		return this.uniqueOperators.length === 1;
+		// return true;
+	},
 
 	actions: {
 		clickYes() {

--- a/app/components/operator-form/component.js
+++ b/app/components/operator-form/component.js
@@ -1,14 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-	operatorsIncluded: Ember.computed.mapBy('operators', 'name'),
-	uniqueOperators: Ember.computed.uniq('operatorsIncluded'),
-	operatorsInFeed: Ember.get('this.operatorsInFeed'),
-	singleOperator: function(){
-		return this.uniqueOperators.length === 1;
-		// return true;
-	},
-
+	
 	actions: {
 		clickYes() {
 			this.set('operator.include_in_changeset', true);

--- a/app/components/operator-form/template.hbs
+++ b/app/components/operator-form/template.hbs
@@ -1,5 +1,5 @@
 <div class="container input-form">
-{{#unless numberOfOperators}}
+{{#unless singleOperator}}
 	<div class="row">
 		<div class="col-sm-12 col-xs-12 input-section">
 			<div class="input-form-label">Include this operator?</div>

--- a/app/components/operator-form/template.hbs
+++ b/app/components/operator-form/template.hbs
@@ -1,4 +1,5 @@
 <div class="container input-form">
+<!-- if more than one operator in feed -->
 	<div class="row">
 		<div class="col-sm-12 col-xs-12 input-section">
 			<div class="input-form-label">Include this operator?</div>
@@ -9,6 +10,7 @@
 		    </div>
   		</div>
 	</div>
+<!-- /if -->
 	<div class="row">
 		<div class="col-sm-12 col-xs-12 input-section">
 			<div class="input-form-label">Operator full name</div>

--- a/app/components/operator-form/template.hbs
+++ b/app/components/operator-form/template.hbs
@@ -1,5 +1,5 @@
 <div class="container input-form">
-<!-- if more than one operator in feed -->
+{{#unless numberOfOperators}}
 	<div class="row">
 		<div class="col-sm-12 col-xs-12 input-section">
 			<div class="input-form-label">Include this operator?</div>
@@ -10,7 +10,7 @@
 		    </div>
   		</div>
 	</div>
-<!-- /if -->
+{{/unless}}
 	<div class="row">
 		<div class="col-sm-12 col-xs-12 input-section">
 			<div class="input-form-label">Operator full name</div>

--- a/app/feeds/new/add-operator/controller.js
+++ b/app/feeds/new/add-operator/controller.js
@@ -1,26 +1,17 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-	operatorsIncluded: Ember.computed.mapBy('operators', 'include_in_changeset'),
-	numberIncluded: Ember.computed.uniq('operatorsIncluded'),
+	operatorsIncluded: Ember.computed.mapBy('model.operators', 'include_in_changeset'),
 
 	singleOperator: Ember.computed('model.operators_in_feed', function(){
-		if (this.minimumOperator !== 0){
-			console.log("minimumOperator !== 0");
-			console.log("operatorsIncluded: " + operatorsIncluded);
-		}
 		return this.get('model.operators_in_feed').length === 1;
 	}),
 
-	// minimumOperator: Ember.computed('this.model.operator.@each.include_in_changeset', function(){
-	// 	return this.operator.filterBy('this.model.operator.include_in_changeset', true).get('length') >= 1; 
-	// })
-	minimumOperator: function() {
+	minimumOperator: Ember.computed('model.operators.@each.include_in_changeset', function(){
 		var operators = this.get('model.operators');
-
-		// console.log('minimumOperator: ' + operators.filterBy('include_in_changeset', true).get('length'));
-		return operators.filterBy('include_in_changeset', true).get('length');
-	}.property()
+		return operators.filterBy('include_in_changeset', true).get('length'); 
+	})
+	
 });
 
 

--- a/app/feeds/new/add-operator/controller.js
+++ b/app/feeds/new/add-operator/controller.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-	numberOfOperators: Ember.computed('model.operators_in_feed', function(){
+	singleOperator: Ember.computed('model.operators_in_feed', function(){
 		return this.get('model.operators_in_feed').length === 1;
 	})
 

--- a/app/feeds/new/add-operator/controller.js
+++ b/app/feeds/new/add-operator/controller.js
@@ -3,7 +3,17 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
 
 	singleOperator: Ember.computed('model.operators_in_feed', function(){
+		if (this.minimumOperator !== 0){
+			console.log("minimumOperator !== 0");
+		}
 		return this.get('model.operators_in_feed').length === 1;
-	})
+	}),
 
+	// minimumOperator: Ember.computed('this.model.operator.@each.include_in_changeset', function(){
+	// 	return this.operator.filterBy('this.model.operator.include_in_changeset', true).get('length') >= 1; 
+	// })
+	minimumOperator: function() {
+		console.log('minimumOperator: ' + this.get('model.operators').filterBy('include_in_changeset', true).get('length'));
+		return this.get('model.operators').filterBy('include_in_changeset', true).get('length');
+	}.property('model.operators@each.include_in_changeset')
 });

--- a/app/feeds/new/add-operator/controller.js
+++ b/app/feeds/new/add-operator/controller.js
@@ -1,4 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+
+	numberOfOperators: Ember.computed('model.operators_in_feed', function(){
+		return this.get('model.operators_in_feed').length === 1;
+	})
+
 });

--- a/app/feeds/new/add-operator/controller.js
+++ b/app/feeds/new/add-operator/controller.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+	operatorsIncluded: Ember.computed.mapBy('operators', 'include_in_changeset'),
+	numberIncluded: Ember.computed.uniq('operatorsIncluded'),
 
 	singleOperator: Ember.computed('model.operators_in_feed', function(){
 		if (this.minimumOperator !== 0){
 			console.log("minimumOperator !== 0");
+			console.log("operatorsIncluded: " + operatorsIncluded);
 		}
 		return this.get('model.operators_in_feed').length === 1;
 	}),
@@ -13,7 +16,11 @@ export default Ember.Controller.extend({
 	// 	return this.operator.filterBy('this.model.operator.include_in_changeset', true).get('length') >= 1; 
 	// })
 	minimumOperator: function() {
-		console.log('minimumOperator: ' + this.get('model.operators').filterBy('include_in_changeset', true).get('length'));
-		return this.get('model.operators').filterBy('include_in_changeset', true).get('length');
-	}.property('model.operators@each.include_in_changeset')
+		var operators = this.get('model.operators');
+
+		// console.log('minimumOperator: ' + operators.filterBy('include_in_changeset', true).get('length'));
+		return operators.filterBy('include_in_changeset', true).get('length');
+	}.property()
 });
+
+

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -16,6 +16,7 @@
 </div>
 <br>
 <!-- if one or more operator is selected to include in feed -->
+{{#if minimumOperator}}
 <div class="container email-input-form">
 	<div class="row" align="left">
 			{{#link-to 'feeds.new.license' class="btn btn-default"}}
@@ -23,6 +24,7 @@
 			{{/link-to}}
 	</div>
 </div>
-<!-- else -->
+{{else}}
+Include an operator!
 <!-- display button asking to include at least one operator -->
-<!-- /if -->
+{{/if}}

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -15,6 +15,7 @@
 	{{/each}}
 </div>
 <br>
+<!-- if one or more operator is selected to include in feed -->
 <div class="container email-input-form">
 	<div class="row" align="left">
 			{{#link-to 'feeds.new.license' class="btn btn-default"}}
@@ -22,3 +23,6 @@
 			{{/link-to}}
 	</div>
 </div>
+<!-- else -->
+<!-- display button asking to include at least one operator -->
+<!-- /if -->

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -10,7 +10,7 @@
 
 <div>
 	{{#each operator in model.operators}}
-		{{operator-form operator=operator}}
+		{{operator-form operator=operator numberOfOperators=numberOfOperators}}
 		<br>
 	{{/each}}
 </div>

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -10,7 +10,7 @@
 
 <div>
 	{{#each operator in model.operators}}
-		{{operator-form operator=operator numberOfOperators=numberOfOperators}}
+		{{operator-form operator=operator singleOperator=singleOperator}}
 		<br>
 	{{/each}}
 </div>


### PR DESCRIPTION
Closes #107 

This PR adds functionality to only render an include/do not include toggle for each operator if there are multiple operators in a feed. It also adds that, in the case of multiple operators, the user cannot progress to the next step unless at least one operator is marked to be included in the changeset.