### PR TITLE
fixing CDN base URLs

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,9 +5,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   var prependUrl;
   if (EmberApp.env() === 'staging') {
-    prependUrl = 'http://d2tkmr00hnrtoq.cloudfront.net/';
+    prependUrl = 'http://d2tkmr00hnrtoq.cloudfront.net/feed-registry/';
   } else if (EmberApp.env() === 'production') {
-    prependUrl = 'https://d11xhlzkgsq6oc.cloudfront.net';
+    prependUrl = 'https://d11xhlzkgsq6oc.cloudfront.net/feed-registry/';
   }
 
   var app = new EmberApp(defaults, {


### PR DESCRIPTION
Assets are getting uploaded to `/feed-registry/` so the CDN URLs need to reflect that, too.

related to #94