### PR TITLE
Suggestions for UI text for add a feed wizard

### DIFF
--- a/app/components/operator-form/country-region-select/template.hbs
+++ b/app/components/operator-form/country-region-select/template.hbs
@@ -7,7 +7,7 @@
   </div>
 </div>
 <div class="col-sm-4 col-xs-12 input-section">
-  <div class="input-form-label">State</div>
+  <div class="input-form-label">State or Province</div>
   <div class="input-form-field">
     {{#power-select options=selectedRegions searchField="name" selected=selectedRegion onchange=(action "setRegion") as |region|}}
       {{region.name}}

--- a/app/components/operator-form/template.hbs
+++ b/app/components/operator-form/template.hbs
@@ -6,7 +6,7 @@
 				<div class="input-form-field">
 					<button class="btn btn-default {{if operator.include_in_changeset "active"}}" type="button" {{action "clickYes"}}>Yes</button>
 					<button class="btn btn-default {{unless operator.include_in_changeset "active"}}" type="button" {{action "clickNo"}}>No</button>
-					
+
 		    </div>
   		</div>
 	</div>
@@ -30,12 +30,12 @@
 	<div class="row">
 		{{operator-form/country-region-select countryName=operator.country regionName=operator.state}}
 		<div class="col-sm-4 col-xs-12 input-section">
-			<div class="input-form-label">Municipality/Region</div>
+			<div class="input-form-label">Municipality or region (optional)</div>
 			<div class="input-form-field">{{input type="text" value=operator.metro placeholder="e.g. Oakland"}}</div>
   		</div>
 	</div>
 
 </div>
 <div class="form-caption">
-	For operators that spread across multiple cities, metros, or states, specify the operator headquarters
+	For operators that spread across multiple cities or states, specify the operator headquarters.
 </div>

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -4,7 +4,7 @@
 
 <div class="add-operator-info">
 	<p>
-		We've fetched the GTFS feed from that URL, parsed it, and listed out the {{model.operators.length}} operator(s) listed in the feed. For each operator, please check its detail and add in any extra information about its location.
+		Transitland checked your feed and found the following number of operators: {{model.operators.length}}. Review the information below and provide additional details about each operator and location it serves. All fields are required unless otherwise indicated.
 	</p>
 </div>
 
@@ -24,7 +24,7 @@
 					Next >
 			{{/link-to}}
 		{{else}}
-			<div class="btn-disabled">Please include at least one operator</div>
+			<div class="btn-disabled">Please include at least one operator.</div>
 		{{/if}}
 	</div>
 </div>

--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -7,7 +7,7 @@
 </div>
 <div class="add-operator-info">
 	<p>
-		Ready to add a feed to Transitland? The first step is to specify the website address for a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. The URL must end with .zip and be hosted by a transit operator or other authoritative source.
+		Ready to add a feed to Transitland? The first step is to specify the web address (URL) to a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. Your link should point directly to a .zip file that is hosted by a transit operator or other authoritative source.
 	</p>
 </div>
 <form {{action "next" on="submit"}}>

--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -7,7 +7,7 @@
 </div>
 <div class="add-operator-info">
 	<p>
-		Ready to add a feed to Transitland? The first step is to specify the web address (URL) to a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. Your link should point directly to a .zip file that is hosted by a transit operator or other authoritative source.
+		Ready to add a feed to Transitland? The first step is to find the web address (URL) to a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. Your link should point directly to a .zip file that is hosted by a transit operator or other authoritative source.
 	</p>
 </div>
 <form {{action "next" on="submit"}}>
@@ -28,7 +28,7 @@
 	</div>
 	<br>
 	<div class="container email-caption">
-		After this feed is part of the Feed Registry, the Transitland servers will periodically check this website for updates.
+		After this feed is added to the Feed Registry, the Transitland servers will periodically check this website for updates.
 	</div>
 	<br>
 	<div class="container email-input-form">

--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -28,7 +28,7 @@
 	</div>
 	<br>
 	<div class="container email-caption">
-		After this feed is part of the Feed Registry, the Transitland servers will periodically check this URL for updates.
+		After this feed is part of the Feed Registry, the Transitland servers will periodically check this website for updates.
 	</div>
 	<br>
 	<div class="container email-input-form">

--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -7,15 +7,15 @@
 </div>
 <div class="add-operator-info">
 	<p>
-		Ready to start adding a feed to Transitland? Step #1 is to find the URL for a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. The feed should live on a transit authority's server or another authoritative source.
+		Ready to add a feed to Transitland? The first step is to specify the website address for a <abbr title="General Transit Feed Specification">GTFS</abbr> feed. The URL must end with .zip and be hosted by a transit operator or other authoritative source.
 	</p>
 </div>
 <form {{action "next" on="submit"}}>
   <div {{bind-attr class=":container :email-input-form model.errors.url:has-error"}}>
 		<div class="row">
 			<div class="col-sm-12">
-				<div class="input-form-label">GTFS feed URL</div>
-				<div class="input-form-field">{{input type="text" value=model.url placeholder="http://..."}}</div>
+				<div class="input-form-label">Paste the feed URL</div>
+				<div class="input-form-field">{{input type="text" value=model.url placeholder="http://... .zip"}}</div>
 			</div>
 		</div>
     {{#if model.errors}}
@@ -28,7 +28,7 @@
 	</div>
 	<br>
 	<div class="container email-caption">
-		After this feed is added to Transitland, our servers will periodically check this URL for updates
+		After this feed is part of the Feed Registry, the Transitland servers will periodically check this URL for updates.
 	</div>
 	<br>
 	<div class="container email-input-form">

--- a/app/feeds/new/license/template.hbs
+++ b/app/feeds/new/license/template.hbs
@@ -4,13 +4,13 @@
 
 <div class="add-operator-info">
 	<p>
-		Thanks for helping us catalog the contents of the feed. Now, please help us find any licenses or terms attached to the feed.
+		Many feeds have licenses or legal terms that apply to them. Provide as much information as you can about the license for the feed. It is okay if you are unable to answer all the license questions.
 	</p>
 </div>
 <div class="container input-form">
 	<div class="row">
 		<div class="col-sm-12 input-section">
-			<div class="input-form-label">Is a license attached to the feed?
+			<div class="input-form-label">Does the feed have a license?
 				<div class="btn-group" data-toggle="buttons">
 					{{license-form-toggle-button attr=license_present_mode text="Yes" value=true}} {{license-form-toggle-button attr=license_present_mode text="No" value=false}}
 				</div>
@@ -24,13 +24,13 @@
 				<div class="input-form-field">{{input type="text" value=this.model.license_name placeholder="e.g. Creative Commons 2.0"}}</div>
 			</div>
 			<div class="col-sm-5 col-xs-12 input-section">
-				<div class="input-form-label">License URL</div>
+				<div class="input-form-label">License website</div>
 				<div class="input-form-field">{{input type="text" value=this.model.license_url placeholder="http://..."}}</div>
 			</div>
 		</div>
 			<div class="row">
 				<div class="col-sm-12 input-section">
-					<div class="input-form-label">Do you feel comfortable reading and interpreting the license?
+					<div class="input-form-label">Do you feel comfortable interpreting the license?
 						<div class="btn-group" data-toggle="buttons">
 							{{license-form-toggle-button attr=interpret_license_mode text="Yes" value=true}} {{license-form-toggle-button attr=interpret_license_mode text="No" value=false}}
 						</div>
@@ -84,14 +84,14 @@
 <br>
 <div class="container email-input-form">
 	<div class="row">
-		
+
 			{{#link-to 'feeds.new.add-operator' class="btn btn-default" }}
 				&#60; Return to Operator info
 			{{/link-to}}
-		
+
 			{{#link-to 'feeds.new.submit' class="btn btn-default" }}
 				Next >
 			{{/link-to}}
-		
+
 	</div>
 </div>

--- a/app/feeds/new/submit/template.hbs
+++ b/app/feeds/new/submit/template.hbs
@@ -3,7 +3,7 @@
 </div>
 <div class="add-operator-info">
 	<p>
-		Would you like to be notified your changes are live?
+		Provide your contact informtion if you want to be notfied when your feed has been added to the Feed Registry.
 	</p>
 </div>
 

--- a/app/feeds/new/success/template.hbs
+++ b/app/feeds/new/success/template.hbs
@@ -3,8 +3,9 @@
 </div>
 <div class="add-operator-info">
 	<p>
-		Thank you for adding a feed! We have created a changeset to review on Transitland.
+		Thank you for submitting a feed to Transitland!
 		<br>
+		Next, the Transitland team will review the feed you submitted and import it into the Feed Registry. Occasionally, there are issues with the import process that could cause a delay or make the feed unsuitable for posting on Transitland. If you provided your contact information, you will be notified when your feed is part of the Transitland Feed Registry.
 		<br>
 		{{#link-to 'index'}}Return to the Feed Registry{{/link-to}}
 	</p>


### PR DESCRIPTION
Here are a few changes for the UI on the add a feed flow. Please review for proper product messaging (and also that I made them in the right places...), and add more commits as needed!

I believe these should address the issues we've put in for the label text.

Fixes #100 (updates text at the top of the page, also changes box label to be clear to paste in the address; also "website" or "web address" is the style guide preferred term for URL, so made those terms more prominent)
Fixes #101 (this keeps the number of operators found, but might make the structure awkward?)
Fixes #109 (Note - this does not add an Unknown option for the first question of does the feed have a license)
Fixes #131 (states to provinces was changed in the feed table, this updates it in the wizard)

Also:
UI text for #96 to add text to explain what happens at the end

Does not address #99