### PR TITLE
observe current path to scroll to top when path changes

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -2,4 +2,7 @@ import Ember from 'ember';
 
 
 export default Ember.Controller.extend({
+	currentPathChanged: function () {
+		window.scrollTo(0, 0);
+	}.observes('currentPath')
 });

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});


### PR DESCRIPTION
Closes #151 

This PR fixes the issue where steps in the flow would render scrolled to the position of the previous step. Steps now render scrolled to the top of the page. 

It may not be the best fix:

- It scrolls all the way to the top of the page, and there is a lot of header information you have to scroll back down past to get to the form
- A better solution might be to render it so that it scrolls to the top of the form (they all start in the same location), but we wouldn't want this to happen when navigating to the "feed" step from the Feed Registry, only between Add a Feed steps.