### PR TITLE
unload the local store with submit action

### DIFF
--- a/app/feeds/new/submit/controller.js
+++ b/app/feeds/new/submit/controller.js
@@ -25,6 +25,7 @@ export default Ember.Controller.extend({
         // TODO: display a better error message
         alert('Error with submission');
       });
+    	this.store.unloadAll();
     },
     agree: function() {
 				if (this.agreeToTerms === false){
@@ -34,5 +35,8 @@ export default Ember.Controller.extend({
 					this.set('agreeToTerms', false);
 				}
 			}
-  }
+ 	 }
+ 	 // clearLocalDatastore: function (){
+   //  	this.store.unloadAll();
+ 	 // }
 });


### PR DESCRIPTION
Closes #96 

This PR adds functionality to to clear out the local datastore when once the user submits a feed. This means that now when the user navigates back to the Feed Registry after submitting a feed, they will not see the feed they just submitted appear temporarily in the FR.