### PR TITLE
pass in operator to country-region-select component

### DIFF
--- a/app/components/operator-form/template.hbs
+++ b/app/components/operator-form/template.hbs
@@ -29,7 +29,7 @@
 		</div>
 	</div>
 	<div class="row">
-		{{operator-form/country-region-select countryName=operator.country regionName=operator.state}}
+		{{operator-form/country-region-select operator=operator countryName=operator.country regionName=operator.state}}
 	</div>
 </div>
 <div class="caption">


### PR DESCRIPTION
Closes #186 

This PR fixes the bug of the region field not being attached to the operator model.