### PR TITLE
remove cancel button from the first step

### DIFF
--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -37,11 +37,6 @@
 
 		<div class="row direction-btn-wrapper">
 			<div class="col-sm-12">
-				<div class="pull-left">
-					{{#link-to 'index' class="btn btn-action"}}
-							<i class="fa fa-chevron-left"></i> Cancel
-					{{/link-to}}
-				</div>
 				<div class="pull-right">
 				 <a class="btn btn-action" role="button"  type="submit" {{action "next"}}> Next <i class="fa fa-chevron-right"></i></a>
 				</div>


### PR DESCRIPTION
Closes #173 

This PR removes the cancel button from the first step of the flow, where the user inputs a URL. (As decided in the UI polish discussion.)