### PR TITLE
move  to the success route

### DIFF
--- a/app/feeds/new/submit/controller.js
+++ b/app/feeds/new/submit/controller.js
@@ -25,7 +25,6 @@ export default Ember.Controller.extend({
         // TODO: display a better error message
         alert('Error with submission');
       });
-    	this.store.unloadAll();
     },
     agree: function() {
 				if (this.agreeToTerms === false){
@@ -36,7 +35,4 @@ export default Ember.Controller.extend({
 				}
 			}
  	 }
- 	 // clearLocalDatastore: function (){
-   //  	this.store.unloadAll();
- 	 // }
 });

--- a/app/feeds/new/success/route.js
+++ b/app/feeds/new/success/route.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	activate: function(){
+		this.store.unloadAll();
+	}
 });


### PR DESCRIPTION
Closes #198 

This PR moves clearing the local data to the success route and uses the `activate` hook, which runs every time the router enters the success route.