### PR TITLE
Update learn more links again

### DIFF
--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -11,9 +11,6 @@
 		Transitland brings together many sources of transit data to build a <a href="https://transit.land/feed-registry" target="_blank">directory of operators and feeds</a> that can be edited by transit enthusiasts and developers. Your contributions can help expand Transitland's coverage throughout the world.
 		</p>
 		<p>
-		Have a look at the <a href="https://github.com/transitland/transitland-docs/blob/master/add-feed.md" target="_blank">documentation</a> to learn more about the submission process.
-		</p>
-		<p>
 		If you know of a feed, please continue below!
 		</p>
 		<p>

--- a/app/feeds/new/license/template.hbs
+++ b/app/feeds/new/license/template.hbs
@@ -8,7 +8,7 @@
 			Many feeds have licenses or legal terms that apply to them. Provide as much information as you can about the license for the feed. It is okay if you are unable to answer all the license questions.
 		</p>
 		<p>
-			{{documentation-link "add-feed.md#provide-the-license-for-the-feed" "Learn more about licenses"}}
+			{{documentation-link "add-feed.md#identify-the-license-for-the-feed" "Learn more about licenses"}}
 		</p>
 	</div>
 		<div class="input-form-wrapper">


### PR DESCRIPTION
This does two things:

1) on first page, removes sentence about reviewing the docs because the learn more link goes to the same help topic. Should add it back if we have a full help system someday.

2) on the license page, fixes section link because I renamed it in the markdown (but does highlight the need for using anchor links in the future).

@souperneon @drewda -- this sound good? 