### PR TITLE
Remove counts#257

### DIFF
--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -1,6 +1,6 @@
 <section id="feed-registry" class="jumbotron">
 	<div class="container">
-		{{intro-copy}} {{country-count operators=model.operators}}
+		{{intro-copy}} 
 
 		<main>
 			{{operator-table operators=model}}

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -1,6 +1,7 @@
 <section id="feed-registry" class="jumbotron">
 	<div class="container">
-		{{intro-copy}} 
+		<div>{{intro-copy}}</div>
+		<br>
 
 		<main>
 			{{operator-table operators=model}}

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -7,7 +7,6 @@
 			{{pagination-controls route="index" hasPreviousPage=hasPreviousPage hasNextPage=hasNextPage previousOffset=previousOffset nextOffset=nextOffset}}
 		</main>
 
-
 		{{#if editingMode}}
 			<div class="row">
 				<div class="col-xs-12">

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -5,7 +5,9 @@
 
 		<main>
 			{{operator-table operators=model}}
-			{{pagination-controls route="index" hasPreviousPage=hasPreviousPage hasNextPage=hasNextPage previousOffset=previousOffset nextOffset=nextOffset}}
+			<div class="row direction-btn-wrapper">
+				{{pagination-controls route="index" hasPreviousPage=hasPreviousPage hasNextPage=hasNextPage previousOffset=previousOffset nextOffset=nextOffset}}
+			</div>
 		</main>
 
 		{{#if editingMode}}

--- a/app/styles/_feeds.scss
+++ b/app/styles/_feeds.scss
@@ -10,6 +10,7 @@
 
 .direction-btn-wrapper {
 	margin-top: 40px;
+	margin-bottom: 40px;
 
 	.btn {
 		background-color: $logo-color-3;

--- a/app/styles/_operators.scss
+++ b/app/styles/_operators.scss
@@ -1,7 +1,7 @@
 //getting rid of padding of jumbotron on add-operator page, because there is sub nav
 #add-operator.jumbotron {
 	padding: 0;
-	padding-bottom: 110px;
+	padding-bottom: 90px;
 }
 
 .fullvw-wrapper {


### PR DESCRIPTION
Closes #257 

This PR removes the operator and country count information from the top of the Feed Registry page. We'll add information about the total number of operators at a later point.

It also changes the style of the buttons used for pagination.