### PR TITLE
scroll to top of page

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 
 
 export default Ember.Controller.extend({
-	currentPathChanged: function () {
-		window.scrollTo(0, 0);
-	}.observes('currentPath')
+	// This is now handled in the router using a didTransition hook
+	// currentPathChanged: function () {
+	// 	window.scrollTo(0, 0);
+	// }.observes('currentPath')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -25,4 +25,10 @@ Router.map(function() {
   });
 });
 
+Ember.Router.reopen({
+  scrollToTop: function() {
+    window.scrollTo(0, 0);
+  }.on('didTransition')
+});
+
 export default Router;


### PR DESCRIPTION
Closes #267 

This PR edits the router so that the window is scrolled to the top on every route transition, including every time the offset is changed. This was previously handled for the add-a-feed flow by the controller, but this didTransition hook within the router will now work with the feed registry pagination offset and the steps of the add a feed flow.