### PR TITLE
clear out properties

### DIFF
--- a/app/application/serializer.js
+++ b/app/application/serializer.js
@@ -14,4 +14,17 @@ export default DS.RESTSerializer.extend({
 
 	primaryKey: 'onestop_id',
 
+	extractMeta: function(store, typeClass, payload) {
+		if (payload && payload.hasOwnProperty('meta')) {
+			if (!payload.meta.hasOwnProperty('next') || Ember.isEmpty(payload.meta.next)) {
+			// The meta.next property will be used by app/mixins/paginated-controller
+			// to decide if there's another page of results. By default, Ember Data
+			// won't nullify the meta properties from a past result. So we'll do that
+			// here...
+				payload.meta.next = null;
+			}
+		}
+		return this._super(store, typeClass, payload);
+	}
+
 });

--- a/app/mixins/paginated-controller.js
+++ b/app/mixins/paginated-controller.js
@@ -4,19 +4,23 @@ export default Ember.Mixin.create({
   perPage: 50,
   queryParams: ["offset"],
   offset: 0,
+
   hasPreviousPage: Ember.computed("offset", function() {
     return this.get("offset") > 0;
   }),
-  hasNextPage: Ember.computed("model", function() {
-    if (this.model.meta && "next" in this.model.meta) {
-      return Ember.isPresent(this.model.meta.next);
+
+  hasNextPage: Ember.computed("model.meta.next", function() {
+    if (Ember.isPresent(this.get('model.meta.next'))) {
+      return true;
     } else {
       return false;
     }
   }),
+  
   previousOffset: Ember.computed("offset", function() {
     return this.get("offset") - this.get("perPage");
   }),
+  
   nextOffset: Ember.computed("offset", function() {
     return this.get("offset") + this.get("perPage");
   })


### PR DESCRIPTION
Closes #259 

This PR modifies the serializer so that it clears out the meta properties when a new request is made. This prevents pagination progress beyond the total number of operators available.