### PR TITLE
Reset pagination on sort#275

### DIFF
--- a/app/components/operator-table/component.js
+++ b/app/components/operator-table/component.js
@@ -47,7 +47,10 @@ export default Ember.Component.extend({
     actions:{
 
         changeSort: function(sortKey) {
-            if (this.get('sortOrder') === 'desc') {
+            if (this.get('sortKey') !== sortKey){
+                var sortOrder = 'asc';
+            }
+            else if (this.get('sortOrder') === 'desc') {
                 var sortOrder = 'asc';
             } else {
                 var sortOrder = 'desc';

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -12,7 +12,8 @@ export default Ember.Controller.extend(PaginatedOrderedController, {
 			this.transitionTo({
 				queryParams: {
 					"sort_order": sortOrder,
-					"sort_key": sortKey
+					"sort_key": sortKey,
+					"offset": 0,
 				}
 			});
 		}


### PR DESCRIPTION
This PR sets the offset to zero when the sort_order has been reset. It also sets the sort_order to ascending if the sort_key passed to the action is not the current sort_key.

Closes #275 