### PR TITLE
remove suggestion to email new feeds

### DIFF
--- a/app/operators/show/template.hbs
+++ b/app/operators/show/template.hbs
@@ -32,7 +32,7 @@
 		</div>
 		<div>
 		<p>
-		If you notice an error, or would like to add a feed, please email us at <a href="mailto:transitland@mapzen.com">transitland@mapzen.com</a>.</p>
+		If you notice an error, please email us at <a href="mailto:transitland@mapzen.com">transitland@mapzen.com</a>.</p>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
This PR removes instructions on the operator detail page to email Transitland to add a new feed.

Closes #254 