### PR TITLE
pass in text to be rendered into the json-endpoint helper

### DIFF
--- a/app/helpers/json-endpoint.js
+++ b/app/helpers/json-endpoint.js
@@ -5,7 +5,6 @@ import ENV from 'feed-registry/config/environment';
 export default Ember.Handlebars.registerBoundHelper('json-endpoint',function(param, attr, text) {
   var entity = '';
   var baseURL = ENV.datastoreHost+'/api/v1/';
-  // var text = "JSON";
 
   if (text === undefined) {
     text = "JSON";

--- a/app/helpers/json-endpoint.js
+++ b/app/helpers/json-endpoint.js
@@ -6,10 +6,6 @@ export default Ember.Handlebars.registerBoundHelper('json-endpoint',function(par
   var entity = '';
   var baseURL = ENV.datastoreHost+'/api/v1/';
 
-  if (text === undefined) {
-    text = "JSON";
-  }
-
   if (param.charAt(0) === 'o'){
     entity = 'operators/';
   } else if (param.charAt(0) === 'f'){

--- a/app/helpers/json-endpoint.js
+++ b/app/helpers/json-endpoint.js
@@ -2,9 +2,14 @@ import Ember from 'ember';
 import ENV from 'feed-registry/config/environment';
 
 
-export default Ember.Handlebars.registerBoundHelper('json-endpoint',function(param, attr) {
+export default Ember.Handlebars.registerBoundHelper('json-endpoint',function(param, attr, text) {
   var entity = '';
   var baseURL = ENV.datastoreHost+'/api/v1/';
+  // var text = "JSON";
+
+  if (text === undefined) {
+    text = "JSON";
+  }
 
   if (param.charAt(0) === 'o'){
     entity = 'operators/';
@@ -13,16 +18,16 @@ export default Ember.Handlebars.registerBoundHelper('json-endpoint',function(par
   }
 
   if (attr === "routes") {
-    return new Ember.Handlebars.SafeString('<a href =' + baseURL + 'routes?operatedBy=' + param +' target = "_blank">JSON</a>');
+    return new Ember.Handlebars.SafeString('<a href =' + baseURL + 'routes?operatedBy=' + param +' target = "_blank">' + text + '</a>');
   } else if (attr === "stops") {
-    return new Ember.Handlebars.SafeString('<a href =' + baseURL + 'stops?servedBy=' + param +' target = "_blank">JSON</a>');
+    return new Ember.Handlebars.SafeString('<a href =' + baseURL + 'stops?servedBy=' + param +' target = "_blank">' + text + '</a>');
   } else {
     if (param.charAt(1) === '-'){
-      return new Ember.Handlebars.SafeString('<a href =' + baseURL + entity + param +' target = "_blank">JSON</a>');
+      return new Ember.Handlebars.SafeString('<a href =' + baseURL + entity + param +' target = "_blank">' + text + '</a>');
     } else if (param.charAt(0) === '/') {
-      return new Ember.Handlebars.SafeString('<a href =' + ENV.datastoreHost + param + ' target = "_blank">JSON</a>');
+      return new Ember.Handlebars.SafeString('<a href =' + ENV.datastoreHost + param + ' target = "_blank">' + text + '</a>');
     } else {
-      return new Ember.Handlebars.SafeString('<a href =' + baseURL + param + ' target = "_blank">JSON</a>');
+      return new Ember.Handlebars.SafeString('<a href =' + baseURL + param + ' target = "_blank">' + text + '</a>');
     }
   }
 });

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -35,7 +35,7 @@
 		{{/if}}
 
 		<p>
-			Looking for machine-readable JSON instead? The {{json-endpoint "/how-it-works/#slide-3" "Datastore API"}} can provide all these {{json-endpoint "operators"}} or all these {{json-endpoint "feeds"}}.
+			Looking for machine-readable JSON instead? The {{json-endpoint "/how-it-works/#slide-3" "" "Datastore API"}} can provide all these {{json-endpoint "operators" "" "operators"}} or all these {{json-endpoint "feeds" "" "feeds"}}.
 		</p>
 
 		<p class="legal-action">

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -35,7 +35,7 @@
 		{{/if}}
 
 		<p>
-			Looking for machine-readable JSON instead? The {{json-endpoint "/how-it-works/#slide-3" "" "Datastore API"}} can provide all these {{json-endpoint "operators" "" "operators"}} or all these {{json-endpoint "feeds" "" "feeds"}}.
+			Looking for machine-readable JSON instead? The <a href="/how-it-works/#slide-3">Datastore API</a> can provide all these {{json-endpoint "operators" "" "operators"}} or all these {{json-endpoint "feeds" "" "feeds"}}.
 		</p>
 
 		<p class="legal-action">

--- a/app/operators/show/template.hbs
+++ b/app/operators/show/template.hbs
@@ -27,12 +27,12 @@
 				</tr>
 				<!-- If a feed has been imported at import_level >= 1 then also link to GeoJSON for routes and stops. -->
 				{{#if feedImportLevelZero}}
-					<tr><td>Operator service area</td><td>{{json-endpoint model.onestop_id}}, {{geojson-endpoint model.onestop_id}} ({{geojson-io model.onestop_id}})</td></tr>
+					<tr><td>Operator service area</td><td>{{json-endpoint model.onestop_id "" "JSON"}}, {{geojson-endpoint model.onestop_id}} ({{geojson-io model.onestop_id}})</td></tr>
 				{{/if}}
 				{{#if feedImportLevelOne}}
-					<tr><td>Routes</td><td>{{json-endpoint model.onestop_id "routes"}}, {{geojson-endpoint model.onestop_id "routes"}} ({{geojson-io model.onestop_id "routes"}})</td></tr>
+					<tr><td>Routes</td><td>{{json-endpoint model.onestop_id "routes" "JSON"}}, {{geojson-endpoint model.onestop_id "routes"}} ({{geojson-io model.onestop_id "routes"}})</td></tr>
 					
-					<tr><td>Stops</td><td>{{json-endpoint model.onestop_id "stops"}}, {{geojson-endpoint model.onestop_id "stops"}} ({{geojson-io model.onestop_id "stops"}})</td></tr>
+					<tr><td>Stops</td><td>{{json-endpoint model.onestop_id "stops" "JSON"}}, {{geojson-endpoint model.onestop_id "stops"}} ({{geojson-io model.onestop_id "stops"}})</td></tr>
 				{{/if}}
 				<!-- If a feed has been imported at import_level >= 2 then also link to a ScheduleStopPair query. -->
 				{{#if feedImportLevelTwo}}


### PR DESCRIPTION
This PR edits the json-endpoint helper so that it receives three arguments. This allows the helper to be used to link to JSON endpoints on the index page and within operator detail pages, and different link text will be rendered based on the third argument.


Closes #292