### PR TITLE
Add a feed help - update base url and links to documentation

### DIFF
--- a/app/components/documentation-link/template.hbs
+++ b/app/components/documentation-link/template.hbs
@@ -1,3 +1,3 @@
-<a href="https://transit.land/documentation/{{linkPath}}" target="_blank">
+<a href="/documentation/{{linkPath}}" target="_blank">
   {{fa-icon icon="question-circle"}} {{linkText}}
 </a>

--- a/app/components/documentation-link/template.hbs
+++ b/app/components/documentation-link/template.hbs
@@ -1,3 +1,3 @@
-<a href="https://github.com/transitland/transitland-docs/blob/master/{{linkPath}}" target="_blank">
+<a href="https://transit.land/documentation/{{linkPath}}" target="_blank">
   {{fa-icon icon="question-circle"}} {{linkText}}
 </a>

--- a/app/feeds/new/add-operator/template.hbs
+++ b/app/feeds/new/add-operator/template.hbs
@@ -4,12 +4,12 @@
 
 <div class="container">
 	<div class="add-operator-info">
-		
+
 		<p>
 			Transitland checked your feed and found {{model.operators.length}} {{#if singleOperator}}operator{{else}}operators{{/if}}. Review the information below and provide additional details about each operator and location it serves.
 		</p>
 		<p>
-			{{documentation-link "add-feed.md#choose-the-transit-operators-in-the-feed" "Learn more about transit operators"}}
+			{{documentation-link "feed-registry/add-a-feed.html#operators" "Learn more about transit operators"}}
 		</p>
 	</div>
 	{{#if feedExists}}

--- a/app/feeds/new/index/template.hbs
+++ b/app/feeds/new/index/template.hbs
@@ -14,7 +14,7 @@
 		If you know of a feed, please continue below!
 		</p>
 		<p>
-			{{documentation-link "add-feed.md#find-the-link-to-the-feed" "Learn more about GTFS feeds"}}
+			{{documentation-link "feed-registry/add-a-feed.html#feedurl" "Learn more about GTFS feeds"}}
 		</p>
 	</div>
 	<form {{action "next" on="submit"}}>
@@ -40,7 +40,7 @@
 				</div>
 			</div>
 		</div>
-		
+
 		<div class="caption">
 			After this feed is added to Transitland, our servers will periodically check this URL for updates.
 		</div>

--- a/app/feeds/new/license/template.hbs
+++ b/app/feeds/new/license/template.hbs
@@ -8,7 +8,7 @@
 			Many feeds have licenses or legal terms that apply to them. Provide as much information as you can about the license for the feed. It is okay if you are unable to answer all the license questions.
 		</p>
 		<p>
-			{{documentation-link "add-feed.md#identify-the-license-for-the-feed" "Learn more about licenses"}}
+			{{documentation-link "feed-registry/add-a-feed.html#license" "Learn more about licenses"}}
 		</p>
 		{{#if feedExists}}
 			{{feed-exists-warning}}


### PR DESCRIPTION
This changes the base url of the documentation-link from https://github.com/transitland/transitland-docs/blob/master/ to https://transit.land/documentation/, now that there is documentation directly on transit.land.

It then updates the individual help links on the Add a Feed pages to point to the new documentation website with an anchor.