### PR TITLE
Filter#290

### DIFF
--- a/app/components/feed-detail/component.js
+++ b/app/components/feed-detail/component.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+	// Ember.computed.gte is a computed property that returns true if the provided dependent property is 
+	// greater than or equal to the provide value.
 	feedImportLevelZero: Ember.computed.gte('feed.import_level_of_active_feed_version', 0),
 	feedImportLevelOne: Ember.computed.gte('feed.import_level_of_active_feed_version', 1),
 

--- a/app/components/intro-copy/component.js
+++ b/app/components/intro-copy/component.js
@@ -1,8 +1,22 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+	importLevel: null,
+	mulitpleImportLevels: null,
+
 	importLevelFilterExists: function(){
-		return this.get('import_level');
+		if (this.importLevel === null){
+			this.importLevel = this.get('import_level');
+		}
+		return this.importLevel;
+	}.property('import_level'),
+
+	multipleImportLevelFiltersExist: function(){
+		if (this.get('import_level').indexOf(',') >= 1){
+			this.multipleImportLevels = this.get('import_level').split(',').map(Number);
+			this.import_level = Math.max.apply(Math,this.multipleImportLevels);
+			return true;
+		}
 	}.property('import_level'),
 
 	feedImportLevelZero: Ember.computed.gte('import_level', 0),

--- a/app/components/intro-copy/component.js
+++ b/app/components/intro-copy/component.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 	importLevelFilterExists: function(){
-		console.log("IL: " + this.get('import_level'));
 		return this.get('import_level');
 	}.property('import_level'),
 

--- a/app/components/intro-copy/component.js
+++ b/app/components/intro-copy/component.js
@@ -1,4 +1,15 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+	importLevelFilterExists: function(){
+		console.log("IL: " + this.get('import_level'));
+		return this.get('import_level');
+	}.property('import_level'),
+
+	feedImportLevelZero: Ember.computed.gte('import_level', 0),
+	feedImportLevelOne: Ember.computed.gte('import_level', 1),
+	feedImportLevelTwo: Ember.computed.gte('import_level', 2),
+	feedImportLevelFour: Ember.computed.gte('import_level', 4),
+
 });
+

--- a/app/components/intro-copy/component.js
+++ b/app/components/intro-copy/component.js
@@ -4,25 +4,29 @@ export default Ember.Component.extend({
 	importLevel: null,
 	mulitpleImportLevels: null,
 
-	importLevelFilterExists: function(){
-		if (this.importLevel === null){
-			this.importLevel = this.get('import_level');
-		}
-		return this.importLevel;
-	}.property('import_level'),
-
-	multipleImportLevelFiltersExist: function(){
-		if (this.get('import_level').indexOf(',') >= 1){
-			this.multipleImportLevels = this.get('import_level').split(',').map(Number);
-			this.import_level = Math.max.apply(Math,this.multipleImportLevels);
-			return true;
-		}
-	}.property('import_level'),
-
 	feedImportLevelZero: Ember.computed.gte('import_level', 0),
 	feedImportLevelOne: Ember.computed.gte('import_level', 1),
 	feedImportLevelTwo: Ember.computed.gte('import_level', 2),
 	feedImportLevelFour: Ember.computed.gte('import_level', 4),
 
-});
+	importLevelFilterExists: function(){
+		if (this.get('import_level')) {
+			this.importLevel = this.get('import_level');
+			if (this.importLevel.includes(',')){
+				this.multipleImportLevels = this.get('import_level').split(',').map(Number);
+				this.importLevel = Math.max.apply(Math,this.multipleImportLevels);
+				this.import_level = this.importLevel;
+			} else {
+				this.import_level = this.importLevel;
+			}
+			return true;
+		}
+	}.property('import_level'),
 
+	supportedLevel: function(){
+		if (this.import_level >= 0 && this.import_level <= 4){
+			return true;
+		}
+	}.property('import_level')
+
+});

--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -4,13 +4,14 @@
 
 <p>The Feed Registry lists all the transit operators and feeds included in Transitland. See what each feed's license will allow you to do with it and click through to get more details about the data included in the feed.</p>
 
-{{#if multipleImportLevelFiltersExist}}
-	{{#if importLevelFilterExists}}
+{{#if importLevelFilterExists}}
+	{{#if supportedLevel}}
 		<p>You are viewing feeds with {{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}} data available.</p>
-		{{#link-to "index"}}
-			{{fa-icon icon="fa-caret-left"}} View All Feeds
-		{{/link-to}}
+	{{else}}
+		<p>You are filtering by an unsupported import level.</p>
 	{{/if}}
+	{{#link-to "index"}}
+		{{fa-icon icon="fa-caret-left"}} View All Feeds
+	{{/link-to}}
 {{/if}}
-
-
+	

--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -5,7 +5,8 @@
 <p>The Feed Registry lists all the transit operators and feeds included in Transitland. See what each feed's license will allow you to do with it and click through to get more details about the data included in the feed.</p>
 
 {{#if importLevelFilterExists}}
-<p>You are viewing feeds with 
-	{{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}}
-	 data available.</p>
+	<p>You are viewing feeds with {{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}} data available.</p>
+	{{#link-to "index"}}
+		{{fa-icon icon="fa-caret-left"}} View All Feeds
+	{{/link-to}}
 {{/if}}

--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -3,3 +3,9 @@
 </div>
 
 <p>The Feed Registry lists all the transit operators and feeds included in Transitland. See what each feed's license will allow you to do with it and click through to get more details about the data included in the feed.</p>
+
+{{#if importLevelFilterExists}}
+<p>You are viewing feeds with 
+	{{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}}
+	 data available.</p>
+{{/if}}

--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -4,9 +4,13 @@
 
 <p>The Feed Registry lists all the transit operators and feeds included in Transitland. See what each feed's license will allow you to do with it and click through to get more details about the data included in the feed.</p>
 
-{{#if importLevelFilterExists}}
-	<p>You are viewing feeds with {{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}} data available.</p>
-	{{#link-to "index"}}
-		{{fa-icon icon="fa-caret-left"}} View All Feeds
-	{{/link-to}}
+{{#if multipleImportLevelFiltersExist}}
+	{{#if importLevelFilterExists}}
+		<p>You are viewing feeds with {{#if feedImportLevelZero}} operator shape{{/if}}{{#if feedImportLevelOne}}, stop points, {{#unless feedImportLevelTwo}}and{{/unless}} route lines{{/if}}{{#if feedImportLevelTwo}}, {{#unless feedImportLevelFour}}and {{/unless}}schedule{{/if}}{{#if feedImportLevelFour}}, and routing{{/if}} data available.</p>
+		{{#link-to "index"}}
+			{{fa-icon icon="fa-caret-left"}} View All Feeds
+		{{/link-to}}
+	{{/if}}
 {{/if}}
+
+

--- a/app/components/operator-table/component.js
+++ b/app/components/operator-table/component.js
@@ -56,6 +56,11 @@ export default Ember.Component.extend({
                 var sortOrder = 'desc';
             }
             this.sendAction('changeSort', sortOrder, sortKey);
-        } 
+        },
+
+        filterByImportLevel: function(){
+            // check val of import level radio buttons
+            // set query param based on this val
+        }
     }
 });

--- a/app/components/operator-table/component.js
+++ b/app/components/operator-table/component.js
@@ -58,9 +58,17 @@ export default Ember.Component.extend({
             this.sendAction('changeSort', sortOrder, sortKey);
         },
 
-        filterByImportLevel: function(){
-            // check val of import level radio buttons
-            // set query param based on this val
-        }
+        // import level changes
+        // filterByImportLevel: function(importLevelSortKey){
+        //     // check val of import level radio buttons
+        //     // set query param based on this val
+        //     if (this.get('importLevel') !== importLevelSortKey){
+        //         var importLevel = importLevelSortKey
+        //     }
+        //     console.log("importLevel: " + importLevel);
+        //     console.log("import_level_of_active_feed_version: " + this.get('import_level_of_active_feed_version'));
+        //     this.sendAction('filterByImportLevel', importLevel, importLevelSortKey);
+
+        // }
     }
 });

--- a/app/components/operator-table/component.js
+++ b/app/components/operator-table/component.js
@@ -57,18 +57,5 @@ export default Ember.Component.extend({
             }
             this.sendAction('changeSort', sortOrder, sortKey);
         },
-
-        // import level changes
-        // filterByImportLevel: function(importLevelSortKey){
-        //     // check val of import level radio buttons
-        //     // set query param based on this val
-        //     if (this.get('importLevel') !== importLevelSortKey){
-        //         var importLevel = importLevelSortKey
-        //     }
-        //     console.log("importLevel: " + importLevel);
-        //     console.log("import_level_of_active_feed_version: " + this.get('import_level_of_active_feed_version'));
-        //     this.sendAction('filterByImportLevel', importLevel, importLevelSortKey);
-
-        // }
     }
 });

--- a/app/components/operator-table/template.hbs
+++ b/app/components/operator-table/template.hbs
@@ -1,4 +1,21 @@
 <div class = "table-container">
+  <!-- toggles for IMPORT_LEVEL 0 (feed + operator), 2 (+ stops, routes, & schedules), and 4 (routable on Turn-by-Turn prod) -->
+  <!-- toggle level 0: query for import level === 0 -->
+  <!-- toggle level 2: query for import level === 2 -->
+  <!-- toggle level 4: query for import level === 4 -->
+
+  <div class="radio">
+    <label><input type="radio" name="optradio">All import levels</label>
+  </div>
+  <div class="radio">
+    <label><input type="radio" name="optradio">Import level: 0 (feed & operator)</label>
+  </div>
+  <div class="radio">
+    <label><input type="radio" name="optradio">Import level: 2 (stops, routes & schedules)</label>
+  </div>
+  <div class="radio">
+    <label><input type="radio" name="optradio">Import level: 4 (routable on Turn-by-Turn)</label>
+  </div>
   <table class="table table-striped">
     <thead>
       <tr>

--- a/app/components/operator-table/template.hbs
+++ b/app/components/operator-table/template.hbs
@@ -1,16 +1,4 @@
 <div class = "table-container">
- <!--  <div class="radio">
-    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "all"}}>All import levels</label>
-  </div>
-  <div class="radio">
-    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "0"}}>Import level: 0 (feed & operator)</label>
-  </div>
-  <div class="radio">
-    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "2"}}>Import level: 2 (stops, routes & schedules)</label>
-  </div>
-  <div class="radio">
-    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "4"}}>Import level: 4 (routable on Turn-by-Turn)</label>
-  </div> -->
   <table class="table table-striped">
     <thead>
       <tr>

--- a/app/components/operator-table/template.hbs
+++ b/app/components/operator-table/template.hbs
@@ -1,21 +1,16 @@
 <div class = "table-container">
-  <!-- toggles for IMPORT_LEVEL 0 (feed + operator), 2 (+ stops, routes, & schedules), and 4 (routable on Turn-by-Turn prod) -->
-  <!-- toggle level 0: query for import level === 0 -->
-  <!-- toggle level 2: query for import level === 2 -->
-  <!-- toggle level 4: query for import level === 4 -->
-
-  <div class="radio">
-    <label><input type="radio" name="optradio">All import levels</label>
+ <!--  <div class="radio">
+    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "all"}}>All import levels</label>
   </div>
   <div class="radio">
-    <label><input type="radio" name="optradio">Import level: 0 (feed & operator)</label>
+    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "0"}}>Import level: 0 (feed & operator)</label>
   </div>
   <div class="radio">
-    <label><input type="radio" name="optradio">Import level: 2 (stops, routes & schedules)</label>
+    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "2"}}>Import level: 2 (stops, routes & schedules)</label>
   </div>
   <div class="radio">
-    <label><input type="radio" name="optradio">Import level: 4 (routable on Turn-by-Turn)</label>
-  </div>
+    <label><input type="radio" name="optradio" {{action "filterByImportLevel" "4"}}>Import level: 4 (routable on Turn-by-Turn)</label>
+  </div> -->
   <table class="table table-striped">
     <thead>
       <tr>

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -4,6 +4,18 @@ import ENV from 'feed-registry/config/environment';
 
 
 export default Ember.Controller.extend(PaginatedOrderedController, {
+	queryParams: ['import_level'],
+	import_level: null,
+	filterByImportLevel: Ember.computed('import_level', function(){
+		var import_level = this.get('import_level');
+		var operators = this.get('model');
+
+		if (import_level) {
+			return operators.filterBy('import_level', import_level);	
+		} else {
+			return operators;
+		}
+	}),
 	editingMode: Ember.computed(function(){
 		return ENV.allowEditingMode;
 	}),

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -1,6 +1,10 @@
 <section id="feed-registry" class="jumbotron">
 	<div class="container">
-		<div>{{intro-copy}}</div>
+		{{#if import_level}}
+			<div>{{intro-copy import_level=import_level}}</div>
+		{{else}}
+			<div>{{intro-copy}}</div>
+		{{/if}}
 		<br>
 
 		<main>

--- a/app/mixins/paginated-ordered-controller.js
+++ b/app/mixins/paginated-ordered-controller.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   perPage: 50,
-  queryParams: ["offset", "sort_order", "sort_key"],
+  queryParams: ["offset", "sort_order", "sort_key", "import_level"],
   offset: 0,
   sort_order: "asc",
   sort_key: "name",

--- a/app/mixins/paginated-ordered-controller.js
+++ b/app/mixins/paginated-ordered-controller.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   perPage: 50,
-  queryParams: ["offset", "sort_order", "sort_key", "import_level"],
+  queryParams: ["offset", "sort_order", "sort_key"],
   offset: 0,
   sort_order: "asc",
   sort_key: "name",

--- a/app/operators/show/controller.js
+++ b/app/operators/show/controller.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 	operatorFeeds: Ember.computed.mapBy('model','feed'),
+	// Ember.computed.gte is a computed property that returns true if the provided dependent property is 
+	// greater than or equal to the provide value.
 	feedImportLevelZero: Ember.computed.gte('model.feeds.firstObject.import_level_of_active_feed_version', 0),
 	feedImportLevelOne: Ember.computed.gte('model.feeds.firstObject.import_level_of_active_feed_version', 1),
 	feedImportLevelTwo: Ember.computed.gte('model.feeds.firstObject.import_level_of_active_feed_version', 2),

--- a/app/operators/show/template.hbs
+++ b/app/operators/show/template.hbs
@@ -2,7 +2,7 @@
 	<div class="container">
 		<div class="page-container operator-page">
 		{{#link-to "index"}}
-			{{fa-icon icon="fa-caret-left"}} Feed Registry
+			{{fa-icon icon="fa-caret-left"}} All Feeds
 		{{/link-to}}
 			<h3 class = "agency-name">{{model.name}} {{#if model.short_name}}
 			({{model.short_name}})


### PR DESCRIPTION
This PR adds functionality to allow filtering by import level via the URL. When a filtered list is rendered, a message provides information about the data available at that import level. When an unsupported number or string is used, the user sees a message letting them know.

In the future, this message could be a column with icons indicating what data is available.

closes #290