### PR TITLE
Filter text updates

### DIFF
--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -14,7 +14,6 @@
 	{{else}}
 		<p>You are filtering by an unsupported import level.</p>
 	{{/if}}
-	<!-- or should I use a regular link to the FR here? -->
 	{{#link-to "index" (query-params import_level="null")}}
 		{{fa-icon icon="fa-caret-left"}} View All Feeds
 	{{/link-to}}

--- a/app/components/intro-copy/template.hbs
+++ b/app/components/intro-copy/template.hbs
@@ -14,7 +14,8 @@
 	{{else}}
 		<p>You are filtering by an unsupported import level.</p>
 	{{/if}}
-	{{#link-to "index" (query-params import_level="")}}
+	<!-- or should I use a regular link to the FR here? -->
+	{{#link-to "index" (query-params import_level="null")}}
 		{{fa-icon icon="fa-caret-left"}} View All Feeds
 	{{/link-to}}
 {{/if}}

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -4,5 +4,10 @@ import PaginatedOrderedRoute from 'feed-registry/mixins/paginated-ordered-route'
 export default Ember.Route.extend(PaginatedOrderedRoute, {
 	model: function(params) {
 		return this.store.query('operator', params);
+	},
+	actions: {
+		queryParamsDidChange: function(){
+			this.refresh();
+		}
 	}
 });


### PR DESCRIPTION
This PR fixes a bug where the queryparam wasn't cleared when navigating to view the entire, unfiltered list of feeds.

It also removes the import_level query param from the URL when navigating away.

Resolves #314