### PR TITLE
location name no longer persists in search bar.

### DIFF
--- a/app/components/operator-form/styles.scss
+++ b/app/components/operator-form/styles.scss
@@ -26,3 +26,4 @@
 	line-height: inherit;
 	box-sizing: border-box;
 }
+

--- a/app/components/operator-table/component.js
+++ b/app/components/operator-table/component.js
@@ -16,8 +16,7 @@ export default Ember.Component.extend({
             return true;
         }
     }),
-
-	 
+ 
     nameSortClass: Ember.computed('sortKey', 'sortOrder', function() {
         if (this.get('sortKey') === 'name' && this.get('sortOrder') === 'asc') {
             return 'sort-down';
@@ -69,5 +68,10 @@ export default Ember.Component.extend({
             }
             this.sendAction('changeSort', sortOrder, sortKey);
         },
+        resetPlace: function(){
+          this.sendAction('resetPlace', "null");
+        }
     }
+
+
 });

--- a/app/components/operator-table/template.hbs
+++ b/app/components/operator-table/template.hbs
@@ -1,6 +1,6 @@
 <div class = "table-container">
   {{#if queryParamExists}}
-        {{#link-to "index" (query-params import_level="null" country="null" state="null" metro="null" name="null")}}
+        {{#link-to "index" (query-params place="null" import_level="null" country="null" state="null" metro="null" name="null" resetPlace=(action "resetPlace"))}}
           {{fa-icon icon="fa-caret-left"}} View All Feeds
         {{/link-to}}
   {{/if}}
@@ -22,3 +22,4 @@
     </tbody>
   </table>
 </div>
+

--- a/app/components/search-bar/component.js
+++ b/app/components/search-bar/component.js
@@ -5,9 +5,9 @@ export default Ember.Component.extend({
   countries: null,
   country: null,
   typeOfPlace: null,
-
-  actions: {
-
+  selected: null,
+  
+  actions: { 
     findPlaces: function(){
       this.sendAction('findPlaces');
       var data = this.model.get('firstObject');
@@ -34,6 +34,7 @@ export default Ember.Component.extend({
 
     setPlace: function(place){
       this.set('place', place);
+      this.set('selected', null);
       if (this.countries.indexOf(place) >= 0){
         this.set('typeOfPlace', 'country');
       } else if (this.states.indexOf(place) >= 0){

--- a/app/components/search-bar/template.hbs
+++ b/app/components/search-bar/template.hbs
@@ -1,9 +1,9 @@
 {{#power-select
-  selected=place
+  selected=selected
   options=places
   onopen=(action "findPlaces")
   onclose=(action "filterByPlace")
-  placeholder="Type to filter by operator name or location..."
+  placeholder="Type to filter by location..."
   onchange=(action "setPlace")
   as |place|
 }}

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -12,7 +12,8 @@ export default Ember.Controller.extend(PaginatedOrderedController, {
 	state: null,
 	metro: null,
 	name: null,
-	
+	selected: null,
+
 	
 	filterByImportLevel: Ember.computed('import_level', function(){
 		var import_level = this.get('import_level');
@@ -31,6 +32,10 @@ export default Ember.Controller.extend(PaginatedOrderedController, {
 		return this.store.findAll('geography');
 	}),
 	actions: {
+		resetPlace: function(){
+			this.set('selected', null);
+		},
+		
 		transitionToNewSort: function(sortOrder, sortKey){
 			this.transitionTo({
 				queryParams: {

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -8,6 +8,7 @@ export default Ember.Route.extend(PaginatedOrderedRoute, {
 	actions: {
 		queryParamsDidChange: function(){
 			this.refresh();
+			// this.set('place', null);
 		}
 	}
 });

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -5,10 +5,10 @@
 		{{else}}
 			<div>{{intro-copy operators=model}}</div>
 		{{/if}}
-		<div>{{search-bar findPlaces=(action "findPlaces") filterByPlace=(action "filterByPlace") model=placesModel}}</div>
+		<div>{{search-bar findPlaces=(action "findPlaces") filterByPlace=(action "filterByPlace") selected=selected place=place model=placesModel}}</div>
 		<br>
 		<main>
-			{{operator-table operators=model sortOrder=sort_order sortKey=sort_key import_level=import_level country=country state=state metro=metro name=name changeSort=(action "transitionToNewSort")}}
+			{{operator-table operators=model sortOrder=sort_order sortKey=sort_key selected=selected import_level=import_level country=country state=state metro=metro name=name changeSort=(action "transitionToNewSort")}}
 			<div class="row direction-btn-wrapper">
 				{{pagination-controls route="index" hasPreviousPage=hasPreviousPage hasNextPage=hasNextPage previousOffset=previousOffset nextOffset=nextOffset}}
 			</div>

--- a/app/mixins/paginated-ordered-route.js
+++ b/app/mixins/paginated-ordered-route.js
@@ -19,6 +19,9 @@ export default Ember.Mixin.create({
     },
     metro: {
       refreshModel: true
+    },
+    name: {
+      refreshModel: true
     }
 
   }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -12,3 +12,5 @@
         "pod-styles",
         "ember-power-select",
         "bower_components/font-awesome/scss/font-awesome";
+
+$ember-power-select-border-color: #000000;

--- a/app/styles/shared/_variables.scss
+++ b/app/styles/shared/_variables.scss
@@ -60,3 +60,4 @@ $logo-hover-colors: ();
         @content;
     }
 }
+


### PR DESCRIPTION
location name no longer persists in search bar. this is better than over-persisting, but it can be improved: the location name should remain in the search bar until navigating back to all feeds view. Will create a new issue for this.

Resolves #324 